### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ Please refer to the following workflow-specific
 + DataJoint for Python or MATLAB
     + Yatsenko D, Reimer J, Ecker AS, Walker EY, Sinz F, Berens P, Hoenselaar A, Cotton RJ, Siapas AS, Tolias AS. DataJoint: managing big scientific data using MATLAB or Python. bioRxiv. 2015 Jan 1:031658. doi: https://doi.org/10.1101/031658
 
-    + DataJoint ([RRID:SCR_014543](https://scicrunch.org/resolver/SCR_014543)) - DataJoint for < Python or MATLAB > (version < enter version number >)
+    + DataJoint ([RRID:SCR_014543](https://scicrunch.org/resolver/SCR_014543)) - DataJoint for `<Select Python or MATLAB>` (version `<Enter version number>`)
 
 + DataJoint Elements
     + Yatsenko D, Nguyen T, Shen S, Gunalan K, Turner CA, Guzman R, Sasaki M, Sitonic D, Reimer J, Walker EY, Tolias AS. DataJoint Elements: Data Workflows for Neurophysiology. bioRxiv. 2021 Jan 1. doi: https://doi.org/10.1101/2021.03.30.437358
 
-    + DataJoint Elements ([RRID:SCR_021894](https://scicrunch.org/resolver/SCR_021894)) - Element DeepLabCut (version < enter version number >)
+    + DataJoint Elements ([RRID:SCR_021894](https://scicrunch.org/resolver/SCR_021894)) - Element DeepLabCut (version `<Enter version number>`)

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ This repository provides demonstrations for:
 3. Ingestion of model information, and launching evaluation.
 4. Using an ingested model to run pose estimation.
 
+See the [DataJoint Elements documentation](https://elements.datajoint.org) for 
+descriptions of the other `elements` and `workflows` developed as part of this National 
+Institutes of Health (NIH)-funded initiative.
+
 ## Workflow architecture
 
 The deeplabcut workflow presented here uses components from 4 DataJoint elements
@@ -52,7 +56,7 @@ still manage various models and execute pose estimation.
 ## Installation instructions
 
 The installation instructions can be found at the 
-[DataJoint Elements repository](https://github.com/datajoint/datajoint-elements/blob/main/gh-pages/docs/usage/install.md).
+[DataJoint Elements documentation](https://elements.datajoint.org/usage/install/).
 
 ## Interacting with the DataJoint workflow
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Please refer to the following workflow-specific
 + DataJoint for Python or MATLAB
     + Yatsenko D, Reimer J, Ecker AS, Walker EY, Sinz F, Berens P, Hoenselaar A, Cotton RJ, Siapas AS, Tolias AS. DataJoint: managing big scientific data using MATLAB or Python. bioRxiv. 2015 Jan 1:031658. doi: https://doi.org/10.1101/031658
 
-    + DataJoint ([RRID:SCR_014543](https://scicrunch.org/resolver/SCR_014543)) - DataJoint for <Python or MATLAB> (version < enter version number >)
+    + DataJoint ([RRID:SCR_014543](https://scicrunch.org/resolver/SCR_014543)) - DataJoint for < Python or MATLAB > (version < enter version number >)
 
 + DataJoint Elements
     + Yatsenko D, Nguyen T, Shen S, Gunalan K, Turner CA, Guzman R, Sasaki M, Sitonic D, Reimer J, Walker EY, Tolias AS. DataJoint Elements: Data Workflows for Neurophysiology. bioRxiv. 2021 Jan 1. doi: https://doi.org/10.1101/2021.03.30.437358

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ This repository provides demonstrations for:
 3. Ingestion of model information, and launching evaluation.
 4. Using an ingested model to run pose estimation.
 
-For more information on the DataJoint Elements project, please visit https://elements.datajoint.org.  This work is supported by the National Institutes of Health.
++ See the [Element DeepLabCut documentation](https://elements.datajoint.org/description/deeplabcut/) for the background information and development timeline.
+
++ For more information on the DataJoint Elements project, please visit https://elements.datajoint.org.  This work is supported by the National Institutes of Health.
 
 ## Workflow architecture
 

--- a/README.md
+++ b/README.md
@@ -27,21 +27,6 @@ The deeplabcut workflow presented here uses components from 4 DataJoint elements
 (`element-lab`, `element-animal`, `element-session`, and `element-deeplabcut`)
 assembled together to a functional workflow.
 
-### element-lab
-
-![element-lab](https://github.com/datajoint/element-lab/blob/main/images/lab_diagram.svg)
-
-### element-animal
-
-![element-animal](
-https://github.com/datajoint/element-animal/blob/main/images/subject_diagram.svg)
-
-### element-session
-
-![session](https://github.com/datajoint/element-session/blob/main/images/session_diagram.svg)
-
-### Assembled with element-deeplabcut
-
 The DeepLabCut Element is split into `train` and `model` schemas. To manage both model
 training and pose estimation within DataJoint, one would activate both schemas, as
 shown below.

--- a/README.md
+++ b/README.md
@@ -23,8 +23,11 @@ Institutes of Health (NIH)-funded initiative.
 
 ## Workflow architecture
 
-The deeplabcut workflow presented here uses components from 4 DataJoint elements
-(`element-lab`, `element-animal`, `element-session`, and `element-deeplabcut`)
+The deeplabcut workflow presented here uses components from four DataJoint Elements
+([element-lab](https://github.com/datajoint/element-lab), 
+[element-animal](https://github.com/datajoint/element-animal), 
+[element-session](https://github.com/datajoint/element-session), 
+[element-deeplabcut](https://github.com/datajoint/element-deeplabcut))
 assembled together to a functional workflow.
 
 The DeepLabCut Element is split into `train` and `model` schemas. To manage both model

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ This repository provides demonstrations for:
 3. Ingestion of model information, and launching evaluation.
 4. Using an ingested model to run pose estimation.
 
-+ See the [Element DeepLabCut documentation](https://elements.datajoint.org/description/deeplabcut/) for the background information and development timeline.
+See the [Element DeepLabCut documentation](https://elements.datajoint.org/description/deeplabcut/) for the background information and development timeline.
 
-+ For more information on the DataJoint Elements project, please visit https://elements.datajoint.org.  This work is supported by the National Institutes of Health.
+For more information on the DataJoint Elements project, please visit https://elements.datajoint.org.  This work is supported by the National Institutes of Health.
 
 ## Workflow architecture
 

--- a/README.md
+++ b/README.md
@@ -17,9 +17,7 @@ This repository provides demonstrations for:
 3. Ingestion of model information, and launching evaluation.
 4. Using an ingested model to run pose estimation.
 
-See the [DataJoint Elements documentation](https://elements.datajoint.org) for 
-descriptions of the other `elements` and `workflows` developed as part of this National 
-Institutes of Health (NIH)-funded initiative.
+For more information on the DataJoint Elements project, please visit https://elements.datajoint.org.  This work is supported by the National Institutes of Health.
 
 ## Workflow architecture
 

--- a/README.md
+++ b/README.md
@@ -64,3 +64,17 @@ Please refer to the following workflow-specific
 + Ingest data and launch tasks ([03-Process.ipynb](notebooks/03-Process.ipynb))
 + Automate tasks ([04-Automate.ipynb](notebooks/04-Automate_Optional.ipynb))
 + Drop tables ([05-Drop](notebooks/05-Drop_Optional.ipynb))
+
+## Citation
+
++ If your work uses DataJoint and DataJoint Elements, please cite the respective Research Resource Identifiers (RRIDs) and manuscripts.
+
++ DataJoint for Python or MATLAB
+    + Yatsenko D, Reimer J, Ecker AS, Walker EY, Sinz F, Berens P, Hoenselaar A, Cotton RJ, Siapas AS, Tolias AS. DataJoint: managing big scientific data using MATLAB or Python. bioRxiv. 2015 Jan 1:031658. doi: https://doi.org/10.1101/031658
+
+    + DataJoint ([RRID:SCR_014543](https://scicrunch.org/resolver/SCR_014543)) - DataJoint for <Python or MATLAB> (version < enter version number >)
+
++ DataJoint Elements
+    + Yatsenko D, Nguyen T, Shen S, Gunalan K, Turner CA, Guzman R, Sasaki M, Sitonic D, Reimer J, Walker EY, Tolias AS. DataJoint Elements: Data Workflows for Neurophysiology. bioRxiv. 2021 Jan 1. doi: https://doi.org/10.1101/2021.03.30.437358
+
+    + DataJoint Elements ([RRID:SCR_021894](https://scicrunch.org/resolver/SCR_021894)) - Element DeepLabCut (version < enter version number >)


### PR DESCRIPTION
- Add citation section.
- Update links to point to elements.datajoint.org instead of the datajoint-elements GitHub repository.
- Remove images of upstream Elements to shorten readme.