### PR TITLE
Fixed typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # DataJoint Workflow - DeepLabCut
 
 The DataJoint Workflow for DeepLabCut combines multiple DataJoint Elements for
-markerless pose estimation with[DeepLabCut](https://www.deeplabcut.org/).  DataJoint
+markerless pose estimation with [DeepLabCut](https://www.deeplabcut.org/). DataJoint
 Elements collectively standardize and automate data collection and analysis for
-neuroscience experiments.  Each Element is a modular pipeline for data storage and
+neuroscience experiments. Each Element is a modular pipeline for data storage and
 processing with corresponding database tables that can be combined with other Elements
 to assemble a fully functional pipeline.
 


### PR DESCRIPTION
Didn't notice the typo until I pulled to my VSCode for updating `workflow-miniscope` README